### PR TITLE
add runtime in the results container next to highscore

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -148,10 +148,12 @@ function App() {
         if (matched === cards.length && turns){
             // Game over
             const m_highscore = window.localStorage.getItem("highscore")
+            const runtime = window.localStorage.getItem("runtime")
             handleTime(false)
-            if (m_highscore === null || turns < Number(m_highscore)){
+            if (m_highscore === null || turns < Number(m_highscore) || (turns === Number(m_highscore) && elapsedTime < runtime)){
                 // New highscore
                 window.localStorage.setItem("highscore", turns)
+                window.localStorage.setItem("runtime", elapsedTime)
                 soundEffect.src = "audio/celebration.mp3"
                 soundEffect.play()
                 setCelebrationStatus(true)
@@ -190,7 +192,10 @@ function App() {
         ))}
       </div>
       <p>Turns: {turns}</p>
-      <p>HighScore: {highScore}</p>
+      <div className="results-container">
+        <p>HighScore: {highScore}</p>
+        <p>Runtime: {window.localStorage.getItem("runtime") || 0}</p>
+      </div>
       <p>Time Elapsed: {elapsedTime || "Not started"}</p>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,8 @@ body {
   color: var(--text,#fff);
   background: var(--background, #1b1523);
 }
+.results-container{
+  display: flex;
+  justify-content: center;
+  column-gap: 1rem;
+}


### PR DESCRIPTION
Fix #40 
* added a runtime next to highscore in the results container. 
* rendering celebration component for a new case: same highscore with less time