### PR TITLE
Hide unflipped images in dev tools

### DIFF
--- a/src/components/singlecard/SingleCard.js
+++ b/src/components/singlecard/SingleCard.js
@@ -13,8 +13,8 @@ export default function SingleCard({ card, handleChoice, flipped, disabled }) {
         <div className={`card ${flipped && card.matched ? "animation" : ""}`}>
             <div className={flipped ? "flipped" : ""}>
                 <div id='front' className='front' style={{ display: "flex" }}>
-                    <img className="front-background" src={card.src} alt="card front blur background" width="200" height="200" />
-                    <img className="front" src={card.src} alt="card front" width="200" height="200" />
+                    <img className="front-background" src={flipped && card.src} alt="card front blur background" width="200" height="200" />
+                    <img className="front" src={flipped && card.src} alt="card front" width="200" height="200" />
                 </div>
                 <button
                     className="back"


### PR DESCRIPTION
Fixes #54 

### Folded:
<img width="884" height="337" alt="image" src="https://github.com/user-attachments/assets/f6c6dd9f-2210-47f4-af89-0af1f7fa1116" />

### Flipped:
<img width="929" height="407" alt="image" src="https://github.com/user-attachments/assets/860bb1f4-b29b-42ef-a43c-10a26438e429" />
